### PR TITLE
Only maximize windows that support it

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -3,9 +3,20 @@ const Meta = imports.gi.Meta;
 let _windowCreatedId;
 
 function enable() {
-    _windowCreatedId = global.display.connect('window-created', (d, win) =>
-        win.maximize(Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL)
-    );
+    _windowCreatedId = global.display.connect('window-created', (d, win) => {
+        // Only try to maximize windows that are marked to support this.
+        // Other windows (e.g. dialogs) can often actually be maximized,
+        // but then no longer unmaximized by the user, so we really need
+        // to check this.
+        if (win.can_maximize()) {
+            win.maximize(Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL)
+        } else {
+            // Workaround for dialogs that were previously maximized by
+            // us (when we did not check for can_maximize yet) and
+            // remember their size.
+            win.unmaximize(Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL)
+        }
+    });
 }
 
 function disable() {

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -5,6 +5,7 @@
   "url": "https://github.com/aXe1/gnome-shell-extension-maximized-by-default",
   "uuid": "gnome-shell-extension-maximized-by-default@axe1.github.com",
   "shell-version": [
+    "3.32",
     "3.20.4"
   ]
 }

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Maximized by default",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Make all windows maximized on start.",
   "url": "https://github.com/aXe1/gnome-shell-extension-maximized-by-default",
   "uuid": "gnome-shell-extension-maximized-by-default@axe1.github.com",


### PR DESCRIPTION
Previously, all windows were maximized, including dialog windows that cannot normally be maximized (and cannot be unmaximized by the user).

Additionally, this explicitly unmaximizes any windows that are not marked to support maximization. This helps to fix windows that remember their size and position and were previously maximized by this extension. Such windows might still remember their size and fill the screen, but this can usually be fixed by resizing the window manually.

Additionally, this PR adds an extra supported shell version that I've been running with.